### PR TITLE
Fix CloudFlare maximum version

### DIFF
--- a/terraform-modules/dns/cloudflare/main.tf
+++ b/terraform-modules/dns/cloudflare/main.tf
@@ -1,7 +1,8 @@
 provider "cloudflare" {}
 
 resource "cloudflare_record" "domain" {
-  zone_id = "${join(".", slice(split(".", var.domain), 1, length(split(".", var.domain))))}"
+  version = "<= 1.13.0"
+  domain = "${join(".", slice(split(".", var.domain), 1, length(split(".", var.domain))))}"
   name   = "${element(split(".", var.domain), 0)}"
   value  = "${var.public_ip}"
   type   = "A"

--- a/terraform-modules/dns/cloudflare/main.tf
+++ b/terraform-modules/dns/cloudflare/main.tf
@@ -1,7 +1,7 @@
 provider "cloudflare" {}
 
 resource "cloudflare_record" "domain" {
-  domain = "${join(".", slice(split(".", var.domain), 1, length(split(".", var.domain))))}"
+  zone_id = "${join(".", slice(split(".", var.domain), 1, length(split(".", var.domain))))}"
   name   = "${element(split(".", var.domain), 0)}"
   value  = "${var.public_ip}"
   type   = "A"

--- a/terraform-modules/dns/cloudflare/main.tf
+++ b/terraform-modules/dns/cloudflare/main.tf
@@ -1,7 +1,8 @@
-provider "cloudflare" {}
+provider "cloudflare" {
+  version = "<= 1.13.0"
+}
 
 resource "cloudflare_record" "domain" {
-  version = "<= 1.13.0"
   domain = "${join(".", slice(split(".", var.domain), 1, length(split(".", var.domain))))}"
   name   = "${element(split(".", var.domain), 0)}"
   value  = "${var.public_ip}"


### PR DESCRIPTION
The newest version of the terraform CloudFlare module has required fields (e.g. zone_id) which aren't defined here, so it may be best to implement a maximum version of it as done in this PR.